### PR TITLE
:arrow_up: django-audioblock 1.0.2. PMT #101400

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ django-paging==0.2.2
 raven==5.2.0
 django-pagetree==1.0.1
 django-pageblocks==1.0.0
-django-audioblock==1.0.0
+django-audioblock==1.0.2
 django-pagetree_export==0.4
 django-jenkins==0.17.0
 django-smoketest==0.3.0


### PR DESCRIPTION
django-audioblock 1.0.0 was missing the MANIFEST.in file, so templates
didn't get packaged up properly.