### PR TITLE
remove ignored max_length field

### DIFF
--- a/wings/wings_main/models.py
+++ b/wings/wings_main/models.py
@@ -13,7 +13,6 @@ class Participant(models.Model):
 
     id_string = models.BigIntegerField(
         unique=True,
-        max_length=12,
         help_text='ID string should contain exactly 12 digits.')
     created_on = models.DateTimeField(auto_now_add=True, null=False)
     created_by = models.ForeignKey(


### PR DESCRIPTION
Django warns:

    wings_main.Participant.id_string: (fields.W122) 'max_length' is ignored when used with IntegerField
        HINT: Remove 'max_length' from field

So apparently it's not doing anything and we might as well take it
out. If we want to enforce a constraint of 12 chars, we should do it
some other way.