### PR TITLE
remove null from ManyToMany fields

### DIFF
--- a/wings/ssnmtreeblock/models.py
+++ b/wings/ssnmtreeblock/models.py
@@ -28,14 +28,12 @@ class SsnmTreeBlock(models.Model):
     editable_support_types = models.ManyToManyField(
         'SsnmTreeSupportType',
         blank=True,
-        null=True,
         related_name='blocks_where_you_can_edit_this_support_type',
         help_text="Support Types you can *edit* on this page.")
 
     visible_support_types = models.ManyToManyField(
         'SsnmTreeSupportType',
         blank=True,
-        null=True,
         related_name='blocks_where_you_can_see_this_support_type',
         help_text="Support Types you can *see* on this page.")
 


### PR DESCRIPTION
According to `./manage.py check`:

    WARNINGS:
    ssnmtreeblock.SsnmTreeBlock.editable_support_types: (fields.W340) null has no effect on ManyToManyField.
    ssnmtreeblock.SsnmTreeBlock.visible_support_types: (fields.W340) null has no effect on ManyToManyField.